### PR TITLE
Added Square-Root functionality

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -270,8 +270,11 @@ function calculator(btn) {
     else if(btn.type == 'trigo_function') {
         
     }else if(btn.type == 'math_function') {
-        
-    }else if(btn.type == 'key') {
+         //square-root funtionality derived from the btn name property
+       if(btn.name=='square-root'){
+      data.operation.push(btn.symbol + '(')
+      data.formula.push(btn.formula + '(')
+       }else if(btn.type == 'key') {
         
     }
     else if(btn.type == 'calculate') {


### PR DESCRIPTION
The synthax of this functionality is denoted  √(value)....When the square root button is clicked it appears implicitly with an opening parenthesis and the user is expected to click the closing parenthesis button after the value(s) to be square rooted  is(are) been clicked.